### PR TITLE
feat: migrate to app-update 2.1.0 from deprecated play-core 1.9.1

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,8 @@
     <platform name="android">
       <framework src="com.android.installreferrer:installreferrer:1.1" />
       <framework src="com.google.android.gms:play-services-safetynet:16.0.0" />  
-      <framework src="com.google.android.play:core:1.9.1" />
+     <framework src="com.google.android.play:app-update:2.1.0" />
+     <framework src="com.google.android.gms:play-services-tasks:18.0.2" />
       <config-file target="res/xml/config.xml" parent="/*">
         <feature name="sbutility">
           <param name="android-package" value="org.sunbird.config.UtilityPlugin" />


### PR DESCRIPTION
Updated the Play Core dependency to use the new modular app-update library.

Changes:
- Replaced `com.google.android.play:core:1.9.1` with `com.google.android.play:app-update:2.1.0`
- Added `com.google.android.gms:play-services-tasks:18.0.2` dependency

This update aligns with Google's new modular Play Core libraries and fixes compatibility issues with newer Android versions.